### PR TITLE
Fix memory corruption when creating headers for a request to upstream

### DIFF
--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -916,6 +916,7 @@ static int read_upstream_response(http2_session_data *session_data, app_context 
     }
   }
   if (cookiebuf != NULL) {
+    cookiebuf = mrb_realloc(mrb, cookiebuf, cookiebuflen + 1);
     cookiebuf[cookiebuflen] = '\0';
     evhttp_add_header(req->output_headers, "Cookie", cookiebuf);
     mrb_free(mrb, cookiebuf);

--- a/src/mrb_http2_server.c
+++ b/src/mrb_http2_server.c
@@ -901,14 +901,14 @@ static int read_upstream_response(http2_session_data *session_data, app_context 
       memcpy(cookiebuf + cookiebaselen + r->reqhdr[i].valuelen, "; ", 2);
     } else {
       len = r->reqhdr[i].namelen;
-      if (len > 4096)
-        len = 4096;
+      if (len > 4095)
+        len = 4095;
       memcpy(keybuf, r->reqhdr[i].name, len);
       keybuf[len] = '\0';
 
       len = r->reqhdr[i].valuelen;
-      if (len > 4096)
-        len = 4096;
+      if (len > 4095)
+        len = 4095;
       memcpy(valbuf, r->reqhdr[i].value, len);
       valbuf[len] = '\0';
 


### PR DESCRIPTION
There is memory corruption bug when creating headers for a request to upstream because the termination character is written outside of the allocated size.